### PR TITLE
Changed to "move" to "moveend"

### DIFF
--- a/leaflet-hash.js
+++ b/leaflet-hash.js
@@ -53,7 +53,7 @@
         init: function(map) {
             this.map = map;
             
-            this.map.on("move", this.onMapMove, this);
+            this.map.on("moveend", this.onMapMove, this);
             
             // reset the hash
             this.lastHash = null;


### PR DESCRIPTION
My theory is that hash does not need to fire every time the map changes a fraction of a degree. Rather when the map stops moving, get the lat, long and zoom level. Makes it function a bit smoother- especially on mobile.
