### PR TITLE
Reliabler way of checking map readyness state

### DIFF
--- a/leaflet-hash.js
+++ b/leaflet-hash.js
@@ -73,9 +73,9 @@
         
         onMapMove: function(map) {
             // bail if we're moving the map (updating from a hash),
-            // or if the map has no zoom set
+            // or if the map is not yet loaded
             
-            if (this.movingMap || this.map.getZoom() === 0) {
+            if (this.movingMap || !this.map._loaded) {
                 return false;
             }
             


### PR DESCRIPTION
I found that the check on the zoom can have some weird behaviours.
My case was using hash with locate: if you init hash before calling `locate`, so the map hasn't called yet `_resetView`, and so is not fully ready for hash needs.
I think that using the `_loaded` property is more reliable.

Thanks!

Yohan
