### PR TITLE
Expose parseHash as a static method

### DIFF
--- a/leaflet-hash.js
+++ b/leaflet-hash.js
@@ -35,22 +35,23 @@
 		}
 	};
 
+	L.Hash.formatHash = function(map) {
+		var center = map.getCenter(),
+		    zoom = map.getZoom(),
+		    precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
+
+		return "#" + [zoom,
+			center.lat.toFixed(precision),
+			center.lng.toFixed(precision)
+		].join("/");
+	},
+
 	L.Hash.prototype = {
 		map: null,
 		lastHash: null,
 
 		parseHash: L.Hash.parseHash,
-
-		formatHash: function(map) {
-			var center = map.getCenter(),
-			    zoom = map.getZoom(),
-			    precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
-
-			return "#" + [zoom,
-				center.lat.toFixed(precision),
-				center.lng.toFixed(precision)
-			].join("/");
-		},
+		formatHash: L.Hash.formatHash,
 
 		init: function(map) {
 			this.map = map;

--- a/leaflet-hash.js
+++ b/leaflet-hash.js
@@ -13,31 +13,33 @@
 		}
 	};
 
+	L.Hash.parseHash = function(hash) {
+		if(hash.indexOf('#') === 0) {
+			hash = hash.substr(1);
+		}
+		var args = hash.split("/");
+		if (args.length == 3) {
+			var zoom = parseInt(args[0], 10),
+			lat = parseFloat(args[1]),
+			lon = parseFloat(args[2]);
+			if (isNaN(zoom) || isNaN(lat) || isNaN(lon)) {
+				return false;
+			} else {
+				return {
+					center: new L.LatLng(lat, lon),
+					zoom: zoom
+				};
+			}
+		} else {
+			return false;
+		}
+	};
+
 	L.Hash.prototype = {
 		map: null,
 		lastHash: null,
 
-		parseHash: function(hash) {
-			if(hash.indexOf('#') === 0) {
-				hash = hash.substr(1);
-			}
-			var args = hash.split("/");
-			if (args.length == 3) {
-				var zoom = parseInt(args[0], 10),
-				lat = parseFloat(args[1]),
-				lon = parseFloat(args[2]);
-				if (isNaN(zoom) || isNaN(lat) || isNaN(lon)) {
-					return false;
-				} else {
-					return {
-						center: new L.LatLng(lat, lon),
-						zoom: zoom
-					};
-				}
-			} else {
-				return false;
-			}
-		},
+		parseHash: L.Hash.parseHash,
 
 		formatHash: function(map) {
 			var center = map.getCenter(),

--- a/test/spec/hash.js
+++ b/test/spec/hash.js
@@ -53,4 +53,16 @@ describe("L.Hash", function() {
         map.setView([51.505, -0.09], 13);
         expect(location.hash).to.be('');
     });
+
+    it('parses a hash', function() {
+      var parsed = L.Hash.parseHash('#13/20/40');
+      expect(parsed.zoom).to.be(13);
+      expect(parsed.center).to.be.a(L.LatLng);
+      expect(parsed.center).to.eql({lat: 20, lng: 40});
+    });
+
+    it('formats a hash', function() {
+      map.setView([51, 2], 13);
+      expect(L.Hash.formatHash(map)).to.be('#13/51.0000/2.0000');
+    });
 });


### PR DESCRIPTION
This is sometimes useful to be able to do without requiring an instance
of L.Hash.
