### PR TITLE
event handling, to extend to manage other hash arguments

### DIFF
--- a/leaflet-hash.js
+++ b/leaflet-hash.js
@@ -97,6 +97,11 @@
 			if (this.lastHash != hash) {
 				location.replace(hash);
 				this.lastHash = hash;
+				if (this.events['hash']) {
+					for (var i=0; i<this.events['hash'].length; i++) {
+						this.events['hash'][i](hash);
+					}
+				}
 			}
 		},
 

--- a/leaflet-hash.js
+++ b/leaflet-hash.js
@@ -12,7 +12,7 @@
 			this.init(map);
 		}
 
-    this.events = new Object();
+		this.events = new Object();
 	};
 
 	L.Hash.parseHash = function(hash) {
@@ -88,11 +88,11 @@
 			}
 
 			var hash = this.formatHash(this.map);
-      if (this.events['change']) {
-        for (var i=0; i<this.events['change'].length; i++) {
-          hash = this.events['change'][i](hash);
-        }
-      }
+			if (this.events['change']) {
+				for (var i=0; i<this.events['change'].length; i++) {
+					hash = this.events['change'][i](hash);
+				}
+			}
 
 			if (this.lastHash != hash) {
 				location.replace(hash);
@@ -112,49 +112,49 @@
 
 				this.map.setView(parsed.center, parsed.zoom);
 
-        if (this.events['update']) {
-          for (var i=0; i<this.events['update'].length; i++) {
-            this.events['update'][i](hash);
-          }
-        }
+				if (this.events['update']) {
+					for (var i=0; i<this.events['update'].length; i++) {
+						this.events['update'][i](hash);
+					}
+				}
 				this.movingMap = false;
 			} else {
 				this.onMapMove(this.map);
 			}
 		},
 
-    on: function(event, func) {
-      if (! this.events[event]) {
-        this.events[event] = [ func ];
-      } else {
-        this.events[event].push(func);
-      }
-    },
-    off: function(event, func) {
-      if (this.events[event]) {
-        for (var i=0; i<this.events[event].length; i++) {
-          if (this.events[event][i] == func) {
-            this.events[event].splice(i);
-            return;
-          }
-        }
-      }
-    },
-    trigger: function(event) {
-      if (event == "move") {
-        if (! this.movingMap) {
-            this.onMapMove();
-        }
-      }
-    },
-    // setMovingMap()/clearMovingMap() when making multiple changes that affect hash arguments
-    //   ie when moving location and changing visible layers
-    setMovingMap: function() {
-      this.movingMap = true;
-    },
-    clearMovingMap: function() {
-      this.movingMap = false;
-    },
+		on: function(event, func) {
+			if (! this.events[event]) {
+				this.events[event] = [ func ];
+			} else {
+				this.events[event].push(func);
+			}
+		},
+		off: function(event, func) {
+			if (this.events[event]) {
+				for (var i=0; i<this.events[event].length; i++) {
+					if (this.events[event][i] == func) {
+						this.events[event].splice(i);
+						return;
+					}
+				}
+			}
+		},
+		trigger: function(event) {
+			if (event == "move") {
+				if (! this.movingMap) {
+					this.onMapMove();
+				}
+			}
+		},
+		// setMovingMap()/clearMovingMap() when making multiple changes that affect hash arguments
+		//   ie when moving location and changing visible layers
+		setMovingMap: function() {
+			this.movingMap = true;
+		},
+		clearMovingMap: function() {
+			this.movingMap = false;
+		},
 		// defer hash change updates every 100ms
 		changeDefer: 100,
 		changeTimeout: null,

--- a/leaflet-hash.js
+++ b/leaflet-hash.js
@@ -11,6 +11,8 @@
 		if (map) {
 			this.init(map);
 		}
+
+    this.events = new Object();
 	};
 
 	L.Hash.parseHash = function(hash) {
@@ -86,6 +88,12 @@
 			}
 
 			var hash = this.formatHash(this.map);
+      if (this.events['change']) {
+        for (var i=0; i<this.events['change'].length; i++) {
+          hash = this.events['change'][i](hash);
+        }
+      }
+
 			if (this.lastHash != hash) {
 				location.replace(hash);
 				this.lastHash = hash;
@@ -104,12 +112,49 @@
 
 				this.map.setView(parsed.center, parsed.zoom);
 
+        if (this.events['update']) {
+          for (var i=0; i<this.events['update'].length; i++) {
+            this.events['update'][i](hash);
+          }
+        }
 				this.movingMap = false;
 			} else {
 				this.onMapMove(this.map);
 			}
 		},
 
+    on: function(event, func) {
+      if (! this.events[event]) {
+        this.events[event] = [ func ];
+      } else {
+        this.events[event].push(func);
+      }
+    },
+    off: function(event, func) {
+      if (this.events[event]) {
+        for (var i=0; i<this.events[event].length; i++) {
+          if (this.events[event][i] == func) {
+            this.events[event].splice(i);
+            return;
+          }
+        }
+      }
+    },
+    trigger: function(event) {
+      if (event == "move") {
+        if (! this.movingMap) {
+            this.onMapMove();
+        }
+      }
+    },
+    // setMovingMap()/clearMovingMap() when making multiple changes that affect hash arguments
+    //   ie when moving location and changing visible layers
+    setMovingMap: function() {
+      this.movingMap = true;
+    },
+    clearMovingMap: function() {
+      this.movingMap = false;
+    },
 		// defer hash change updates every 100ms
 		changeDefer: 100,
 		changeTimeout: null,


### PR DESCRIPTION
event handling, to extend to manage other hash arguments and map behaviors. 
our use case is representing state of visible tile layers in the hash.

```
on/off
```

adding/removing callback functions for when hash "change", or map "update". callback function manipulates hash, or takes action depending on hash.

```
trigger
```

after making a change to the map state, triggers a response to a map move

```
setMovingMap/clearMovingMap
```

prevent updates while making a series of changes to the map, by bracketing the code block with these calls
