### PR TITLE
Disable map animation on hash change

### DIFF
--- a/leaflet-hash.js
+++ b/leaflet-hash.js
@@ -102,7 +102,7 @@
 			if (parsed) {
 				this.movingMap = true;
 
-				this.map.setView(parsed.center, parsed.zoom);
+				this.map.setView(parsed.center, parsed.zoom, { animate: false});
 
 				this.movingMap = false;
 			} else {


### PR DESCRIPTION
This disables animation for moving map when hash is changed. I don't think this animation should be enabled at all, not only when the map is initialized. Currently the jump at the initialization stage is horrible.

Fixes #35.
