### PR TITLE
Support leaflet v1+ fractional zooms

### DIFF
--- a/leaflet-hash.js
+++ b/leaflet-hash.js
@@ -19,7 +19,7 @@
 		}
 		var args = hash.split("/");
 		if (args.length == 3) {
-			var zoom = parseInt(args[0], 10),
+			var zoom = (L.version >= '1.0.0') ? parseFloat(args[0]) : parseInt(args[0], 10),
 			lat = parseFloat(args[1]),
 			lon = parseFloat(args[2]);
 			if (isNaN(zoom) || isNaN(lat) || isNaN(lon)) {
@@ -40,7 +40,7 @@
 		    zoom = map.getZoom(),
 		    precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
 
-		return "#" + [zoom,
+		return "#" + [(L.version >= '1.0.0') ? zoom.toFixed(precision) : zoom,
 			center.lat.toFixed(precision),
 			center.lng.toFixed(precision)
 		].join("/");


### PR DESCRIPTION
Leaflet v1 supports [fractional zooms](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#animations-improvements-and-fractional-zoom) and reports zooms such as `12.45` from `map.getZoom()`, which leaflet-hash does not expect. As a result, leaflet-hash will display hashes such as `#11.375325620188496/40.7154/-73.9275` but only sets the view at zoom 11. This PR fixes this behavior if the Leaflet version detected is v1+:
- Hash display is now set at the same precision level as lat/lng for more sensible looking URLs.
- Hash is parsed as a float instead of as an integer, so that the map view is set to the correct zoom.

This behavior is not changed on Leaflet versions before v1 (zoom 12 will not start showing up with unnecessary precision, such as `12.0000` for example).
