### PR TITLE
location.hash = hash

### DIFF
--- a/leaflet-hash.js
+++ b/leaflet-hash.js
@@ -87,7 +87,7 @@
 
 			var hash = this.formatHash(this.map);
 			if (this.lastHash != hash) {
-				location.replace(hash);
+				location.hash = hash;
 				this.lastHash = hash;
 			}
 		},


### PR DESCRIPTION
Using location.hash = hash; instead of location.replace(hash) doesn't break the location when coming from a redirection (https://github.com/mlevans/leaflet-hash/issues/45)
