### PR TITLE
set lastHash after calling setView

### DIFF
--- a/leaflet-hash.js
+++ b/leaflet-hash.js
@@ -103,7 +103,8 @@
 				this.movingMap = true;
 
 				this.map.setView(parsed.center, parsed.zoom);
-
+				this.lastHash = hash;
+				
 				this.movingMap = false;
 			} else {
 				this.onMapMove(this.map);


### PR DESCRIPTION
When repeatedly changing between different hashes (without any manual map movement) lastHash often gets "stuck" on a previous value and thus blocks changing back to an already visited (but not active) position. Solution: set lastHash when updating the map via update. 